### PR TITLE
Review download models script

### DIFF
--- a/docker/main/download_models.sh
+++ b/docker/main/download_models.sh
@@ -5,6 +5,26 @@
 
 set -euo pipefail
 
+# 依赖检查
+command_exists() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+if ! command_exists wget && ! command_exists curl; then
+	echo "❌ 需要 wget 或 curl，但系统均未安装"
+	exit 1
+fi
+
+# 目录大小显示函数
+show_folder_size() {
+	local path="$1"
+	if [ -d "$path" ]; then
+		local size
+		size=$(du -sh "$path" 2>/dev/null | awk '{print $1}')
+		echo "   - $path: $size"
+	fi
+}
+
 # 添加调试信息
 echo "🔍 调试信息:"
 echo "  - 脚本路径: $0"
@@ -22,14 +42,14 @@ echo "📁 创建模型缓存目录: $MODEL_CACHE_DIR"
 
 # 检查磁盘空间函数
 check_disk_space() {
-    local required_space=$1  # in MB
-    local available_space=$(df -m / | awk 'NR==2 {print $4}')
-    
-    if [ $available_space -lt $required_space ]; then
-        echo "❌ 磁盘空间不足! 需要 ${required_space}MB，当前可用 ${available_space}MB"
-        return 1
-    fi
-    return 0
+	local required_space=$1  # in MB
+	local available_space=$(df -m "$MODEL_CACHE_DIR" | awk 'NR==2 {print $4}')
+	
+	if [ $available_space -lt $required_space ]; then
+		echo "❌ 磁盘空间不足! 需要 ${required_space}MB，当前可用 ${available_space}MB"
+		return 1
+	fi
+	return 0
 }
 
 # 定义模型下载函数（增强版）

--- a/docker/main/download_models.sh
+++ b/docker/main/download_models.sh
@@ -61,11 +61,11 @@ download_model() {
     local max_retries=5
     local retry_delay=5  # 初始延迟5秒
     
-    echo "📥 下载 $model_dir/$file_name..."
-    mkdir -p "$MODEL_CACHE_DIR/$model_dir"
-    
-    for ((i=1; i<=max_retries; i++)); do
-        echo "🔄 尝试 $i/$max_retries: $url"
+    	echo "📥 下载 $model_dir/$file_name..."
+	mkdir -p "$(dirname "$target_path")"
+	
+	for ((i=1; i<=max_retries; i++)); do
+echo "🔄 尝试 $i/$max_retries: $url"
         
         wget -q --show-progress --tries=3 --timeout=600 --continue -O "$target_path" "$url"
         local wget_exit=$?


### PR DESCRIPTION
## Proposed change
This PR significantly enhances the `download_models.sh` script to improve reliability, robustness, and user feedback.

Key improvements include:
*   **Optimized Downloads**: Hugging Face links now prioritize `curl` with retry and resume capabilities to improve download success rates and handle network issues more gracefully.
*   **Enhanced Robustness**:
    *   Added checks for `wget` or `curl` dependencies.
    *   Corrected disk space calculation to check the `MODEL_CACHE_DIR` specifically.
    *   Ensured parent directories are created before downloading files.
    *   Made the self-test download optional via an environment variable (`ENABLE_DOWNLOAD_SELFTEST`).
*   **Corrected Model Paths**: The ArcFace model is now downloaded into the correct `face_embedding` directory.
*   **Improved Visibility**: A `show_folder_size` function has been added and is called at the end to display the size of downloaded model directories.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (e.g., improved download logic, folder size display)
- [x] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)

---
<a href="https://cursor.com/background-agent?bcId=bc-61131eea-1f60-403e-a89f-ebdcd329fb85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61131eea-1f60-403e-a89f-ebdcd329fb85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

